### PR TITLE
Fix floating point exception error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             binary_name: shai
             asset_name: shai-linux-x86_64
           - os: windows-latest
@@ -41,7 +41,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential
+          sudo apt-get install -y build-essential musl-tools
+
+      - name: Add musl target (Linux)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: rustup target add x86_64-unknown-linux-musl
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -66,10 +70,6 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.target }}-target-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-target-
-
-      - name: Set static linking flag (Linux)
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: echo "RUSTFLAGS=-C target-feature=+crt-static" >> $GITHUB_ENV
 
       - name: Build binary
         run: cargo build --release --target ${{ matrix.target }}

--- a/shai-cli/src/shell/pty.rs
+++ b/shai-cli/src/shell/pty.rs
@@ -218,7 +218,7 @@ impl ShaiPtyManager {
             
             libc::setsid();
             
-            if libc::ioctl(self.slave_fd, libc::TIOCSCTTY as libc::c_ulong, 0) == -1 {
+            if libc::ioctl(self.slave_fd, libc::TIOCSCTTY.try_into().unwrap(), 0) == -1 {
                 libc::exit(1);
             }
             

--- a/shai-llm/Cargo.toml
+++ b/shai-llm/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [dependencies]
 # New LLM module dependencies
 async-trait = "0.1"
+openssl = { version = "0.10", features = ["vendored"] }
+native-tls = { version = "0.2", features = ["vendored"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -49,4 +51,3 @@ path = "src/examples/function_calling.rs"
 [[example]]
 name = "function_calling_streaming"
 path = "src/examples/function_calling_streaming.rs"
-


### PR DESCRIPTION
Passing -Wl,--hash-style=both keeps the .hash section alongside .gnu.hash so fully static glibc builds run on older loaders instead of aborting with SIGFPE on start‑up.

Signed-off-by: Gafaiti Aymane aymane.gafaiti@ovhcloud.com