### PR TITLE
doc: add commands to ? (help) fixes #17

### DIFF
--- a/shai-cli/src/tui/helper.rs
+++ b/shai-cli/src/tui/helper.rs
@@ -10,14 +10,18 @@ impl HelpArea {
         [
             "  ? to print help      tap esc twice to clear input",
             "  / for commands       tap esc while agent is running to cancel",
-            "                       ctrl^c to exit"
+            "                       ctrl^c to exit",
+            "",
+            "  Available Commands:",
+            "  /exit                exit from the tui",
+            "  /tc <method>         set tool call method: [auto | fc | fc2 | so]"
         ].join("\n").to_string()
     }
 }
 
 impl HelpArea {
     pub fn height(&self) -> u16 {
-        2 // content
+        7 // content (3 general help lines + 1 blank + 1 header + 2 command lines)
     }
 
     pub fn draw(&self, f: &mut Frame, area: Rect) {


### PR DESCRIPTION
This fixes #17 by adding the commands list to the help
===
after the fix, entering (?) displays the available commands:
<img width="478" height="344" alt="image" src="https://github.com/user-attachments/assets/c0e0248b-2f85-4c60-bae8-a557a9117ed5" />
