### PR TITLE
fix: make install.sh POSIX compliant Refs:#34

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -131,7 +131,7 @@ update_path() {
     fi
     
     # Check if directory is already in PATH
-    if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+    if [ "${PATH#*:$INSTALL_DIR:}" = "$PATH" ] && [ "${PATH#$INSTALL_DIR:}" = "$PATH" ] && [ "${PATH%:$INSTALL_DIR}" = "$PATH" ] && [ "$PATH" != "$INSTALL_DIR" ]; then
         if [ -n "$shell_profile" ] && [ -f "$shell_profile" ]; then
             echo "export PATH=\"\$PATH:$INSTALL_DIR\"" >> "$shell_profile"
             log_success "Added $INSTALL_DIR to PATH in $shell_profile"
@@ -197,7 +197,7 @@ main() {
 }
 
 # Parse command line arguments
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     case $1 in
         --install-dir)
             INSTALL_DIR="$2"


### PR DESCRIPTION
This PR will fixes #34 by making install.sh POSIX compliant:
Before the PR (note the ``install.sh: 200: [[: not found``):
```bash
~/workspace/shai$ sh install.sh
install.sh: 200: [[: not found
-e [INFO] Installing shai...
-e [INFO] Detected platform: shai-linux-x86_64
-e [INFO] Downloading shai from https://github.com/ovh/shai/releases/download/v0.1.0/shai-linux-x86_64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 16.3M  100 16.3M    0     0  29.6M      0 --:--:-- --:--:-- --:--:-- 29.6M
-e [SUCCESS] shai installed to /home/ubuntu/.local/bin/shai
install.sh: 134: [[: not found
-e [SUCCESS] Installation completed! You can now run 'shai'
```

after the PR:
```bash
~/workspace/shai$ sh install.sh
-e [INFO] Installing shai...
-e [INFO] Detected platform: shai-linux-x86_64
-e [INFO] Downloading shai from https://github.com/ovh/shai/releases/download/v0.1.0/shai-linux-x86_64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 16.3M  100 16.3M    0     0  44.0M      0 --:--:-- --:--:-- --:--:-- 44.0M
-e [SUCCESS] shai installed to /home/ubuntu/.local/bin/shai
-e [SUCCESS] Installation completed! You can now run 'shai'
```
