### PR TITLE
ci: enable binary build on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,95 @@
+name: CI Build
+
+on:
+  push:
+    branches: [ main, dev/*, feature/*, fix/* ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Build for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            binary_name: shai
+            asset_name: shai-linux-x86_64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary_name: shai.exe
+            asset_name: shai-windows-x86_64.exe
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary_name: shai
+            asset_name: shai-macos-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            binary_name: shai
+            asset_name: shai-macos-aarch64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install dependencies (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential musl-tools
+
+      - name: Add musl target (Linux)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: rustup target add x86_64-unknown-linux-musl
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
+
+      - name: Cache target directory
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-${{ matrix.target }}-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-target-
+
+      - name: Build binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Prepare binary (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} ${{ matrix.asset_name }}
+          strip ${{ matrix.asset_name }}
+
+      - name: Prepare binary (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} ${{ matrix.asset_name }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: ${{ matrix.asset_name }}
+          retention-days: 10

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,14 +1,12 @@
-name: CI Build
+name: Unstable Build
 
 on:
   push:
-    branches: [ dev/*, feature/*, fix/* ]
-  pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-    name: Build for ${{ matrix.os }}
+    name: Build Unstable for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -16,19 +14,19 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             binary_name: shai
-            asset_name: shai-linux-x86_64
+            asset_name: shai-unstable-linux-x86_64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary_name: shai.exe
-            asset_name: shai-windows-x86_64.exe
+            asset_name: shai-unstable-windows-x86_64.exe
           - os: macos-latest
             target: x86_64-apple-darwin
             binary_name: shai
-            asset_name: shai-macos-x86_64
+            asset_name: shai-unstable-macos-x86_64
           - os: macos-latest
             target: aarch64-apple-darwin
             binary_name: shai
-            asset_name: shai-macos-aarch64
+            asset_name: shai-unstable-macos-aarch64
 
     steps:
       - name: Checkout code
@@ -87,9 +85,40 @@ jobs:
         run: |
           cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} ${{ matrix.asset_name }}
 
-      - name: Upload build artifacts
+      - name: Upload unstable artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset_name }}
           path: ${{ matrix.asset_name }}
-          retention-days: 10
+          retention-days: 30
+
+  create-unstable-release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Delete existing unstable release
+        continue-on-error: true
+        run: |
+          gh release delete unstable --yes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create unstable release
+        run: |
+          gh release create unstable \
+            --title "Unstable Build (${{ steps.date.outputs.date }})" \
+            --notes "Automated unstable build from commit ${{ github.sha }}" \
+            --prerelease \
+            shai-unstable-linux-x86_64/shai-unstable-linux-x86_64 \
+            shai-unstable-windows-x86_64.exe/shai-unstable-windows-x86_64.exe \
+            shai-unstable-macos-x86_64/shai-unstable-macos-x86_64 \
+            shai-unstable-macos-aarch64/shai-unstable-macos-aarch64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR will: 
- enable build on PUSH on branches: main, dev/*, feature/*, fix/*
- enable build on PR that targets: main
created artefacts are retained for 10 days
- build and publish a "unstable" release for commit on ``main`` branch