### PR TITLE
fix(install.sh): make echo commands POSIX compliant

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -e
 
@@ -16,15 +16,15 @@ NC='\033[0m' # No Color
 
 # Helper functions
 log_info() {
-    echo -e "${BLUE}[INFO]${NC} $1"
+    echo "${BLUE}[INFO]${NC} $1"
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $1"
+    echo "${GREEN}[SUCCESS]${NC} $1"
 }
 
 log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
+    echo "${YELLOW}[WARN]${NC} $1"
 }
 
 log_error() {


### PR DESCRIPTION
`echo` behave differently on different systems.
Running install.sh with sh, as stated in the README, produce this output:
```console
$ sh install.sh
-e [INFO] Installing shai...
-e [INFO] Detected platform: shai-linux-x86_64
-e [INFO] Downloading shai from https://github.com/ovh/shai/releases/download/v0.1.1/shai-linux-x86_64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 16.3M  100 16.3M    0     0  42.1M      0 --:--:-- --:--:-- --:--:-- 57.6M
-e [SUCCESS] shai installed to /home/mrobine/.local/bin/shai
-e [SUCCESS] Installation completed! You can now run 'shai'
```
`-e` are displayed because `echo` do not support flags in POSIX sh