### PR TITLE
feat: shai now display version based on Cargo.toml Refs:#47

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,22 @@ pay attention to a few things:
 4. your work must be signed (see below)
 5. you may contribute through GitHub Pull Requests
  
+# Release Process
+
+When creating a new release, make sure to update the version in the following locations:
+
+1. **Main CLI version**: Update `version` in `shai-cli/Cargo.toml`
+2. **Core crate version**: Update `version` in `shai-core/Cargo.toml` 
+3. **LLM crate version**: Update `version` in `shai-llm/Cargo.toml`
+4. **Macros crate version**: Update `version` in `shai-macros/Cargo.toml`
+
+The version banner in the CLI logo is automatically generated from the main CLI crate version using `env!("CARGO_PKG_VERSION")`, so no manual update is needed for the display version.
+
+After updating versions:
+1. Run `cargo check` to ensure everything compiles
+2. Create a git tag with the new version number
+3. Push the tag to trigger the release workflow
+
 # Submitting Modifications
  
 The contributions should be submitted through Github Pull Requests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.1+3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +1768,7 @@ checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2395,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "shai"
-version = "0.1.1"
+version = "0.1.3-dev"
 dependencies = [
  "ansi-to-tui",
  "async-trait",
@@ -2463,7 +2473,9 @@ dependencies = [
  "chrono",
  "fastrand",
  "futures 0.3.31",
+ "native-tls",
  "openai_dive",
+ "openssl",
  "paste",
  "regex",
  "reqwest",

--- a/shai-cli/Cargo.toml
+++ b/shai-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shai"
-version = "0.1.1"
+version = "0.1.3-dev"
 edition = "2021"
 
 

--- a/shai-cli/src/tui/theme.rs
+++ b/shai-cli/src/tui/theme.rs
@@ -1,14 +1,16 @@
 use rand::Rng;
 
-pub static SHAI_LOGO: &str = r#"
+pub fn shai_logo() -> String {
+    format!(r#"
   ███╗      ███████╗██╗  ██╗ █████╗ ██╗
   ╚═███╗    ██╔════╝██║  ██║██╔══██╗██║
      ╚═███  ███████╗███████║███████║██║
     ███╔═╝  ╚════██║██╔══██║██╔══██║██║
   ███╔═╝    ███████║██║  ██║██║  ██║██║
   ╚══╝      ╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝
-                         version: 0.1.1
-"#;
+                         version: {}
+"#, env!("CARGO_PKG_VERSION"))
+}
 
 pub static SHAI_YELLOW: (u8, u8, u8) = (249,188,81);
 pub static SHAI_GREEN: (u8, u8, u8)  = (18,200,124);
@@ -57,11 +59,11 @@ pub fn apply_gradient(text: &str, from_color: (u8, u8, u8), to_color: (u8, u8, u
 
 
 pub fn logo() -> String {
-    SHAI_LOGO.replace("\n","\r\n")
+    shai_logo().replace("\n","\r\n")
 }
 
 pub fn logo_cyan() -> String {
-    let logo = SHAI_LOGO.replace("\n","\r\n");
+    let logo = shai_logo().replace("\n","\r\n");
     apply_gradient(&logo, (255, 0, 255), (0, 255, 255))
 }
 


### PR DESCRIPTION
This PR will make the banner uses the version from Cargo.toml and fix #47 
<img width="557" height="210" alt="image" src="https://github.com/user-attachments/assets/6de66845-4e4b-4067-b445-f5b027db1a8f" />

Also begin a release section in  CONTRIBUTING.md