### PR TITLE
fix(auth): trim whitespace from input fields before setting environment variables

### DIFF
--- a/shai-cli/src/tui/auth/config_env.rs
+++ b/shai-cli/src/tui/auth/config_env.rs
@@ -77,7 +77,7 @@ impl ModalEnvs {
         // Set environment variables based on provider's required env vars
         for (i, env_var) in self.provider.env_vars.iter().enumerate() {
             if i < self.input_fields.len() {
-                let value = self.input_fields[i].lines().join("\n");
+                let value = self.input_fields[i].lines().join("\n").trim().to_string();
                 if !value.is_empty() {
                     self.env_values.insert(env_var.name.clone(), value);
                 }


### PR DESCRIPTION
This pull request includes a minor improvement to the `shai-cli/src/tui/auth/config_env.rs` file. The change ensures that environment variable values are trimmed of leading and trailing whitespace before being stored. #44 