### PR TITLE
#60: Clarifying compatible OVHCloud models for shai

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,14 @@ cd shai
 
 cargo build --release
 ```
+
+## Compatible OVHCloud endpoints
+
+OVHCloud provides compatible LLM endpoints for using shai with tools. Start by creating a [_Public Cloud_ project in your OVHCloud account](https://www.ovh.com/manager/#/public-cloud), then head to _AI Endpoints_ and retreive your API key. After setting it in shai, you can now select one of these models:
+
+- [Qwen3-32B](https://endpoints.ai.cloud.ovh.net/models/qwen-3-32b)
+- [Mistral-​Small-​3.2-​24B-​Instruct-​2506](https://endpoints.ai.cloud.ovh.net/models/mistral-small-3-2-24b-instruct-2506)
+- [Llama-​3.1-​8B-​Instruct](https://endpoints.ai.cloud.ovh.net/models/llama-3-1-8b-instruct)
+- [Mistral-​7B-​Instruct-​v0.3](https://endpoints.ai.cloud.ovh.net/models/mistral-7b-instruct-v0-3)
+- [Meta-​Llama-​3_3-​70B-​Instruct](https://endpoints.ai.cloud.ovh.net/models/llama-3-3-70b-instruct)
+- [DeepSeek-​R1-​Distill-​Llama-​70B](https://endpoints.ai.cloud.ovh.net/models/deepseek-r1-distill-llama-70b)

--- a/README.md
+++ b/README.md
@@ -91,12 +91,7 @@ cargo build --release
 
 ## Compatible OVHCloud endpoints
 
-OVHCloud provides compatible LLM endpoints for using shai with tools. Start by creating a [_Public Cloud_ project in your OVHCloud account](https://www.ovh.com/manager/#/public-cloud), then head to _AI Endpoints_ and retreive your API key. After setting it in shai, you can now select one of these models:
+OVHCloud provides compatible LLM endpoints for using shai with tools. Start by creating a [_Public Cloud_ project in your OVHCloud account](https://www.ovh.com/manager/#/public-cloud), then head to _AI Endpoints_ and retreive your API key. After setting it in shai, you can:
 
-- [Qwen3-32B](https://endpoints.ai.cloud.ovh.net/models/qwen-3-32b)
-- [Mistral-​Small-​3.2-​24B-​Instruct-​2506](https://endpoints.ai.cloud.ovh.net/models/mistral-small-3-2-24b-instruct-2506)
-- [Mistral-​Nemo-​Instruct-​2407](https://endpoints.ai.cloud.ovh.net/models/mistral-nemo-instruct-2407)
-- [Mistral-​7B-​Instruct-​v0.3](https://endpoints.ai.cloud.ovh.net/models/mistral-7b-instruct-v0-3)
-- [Meta-​Llama-​3_3-​70B-​Instruct](https://endpoints.ai.cloud.ovh.net/models/llama-3-3-70b-instruct)
-- [Llama-​3.1-​8B-​Instruct](https://endpoints.ai.cloud.ovh.net/models/llama-3-1-8b-instruct)
-- [DeepSeek-​R1-​Distill-​Llama-​70B](https://endpoints.ai.cloud.ovh.net/models/deepseek-r1-distill-llama-70b)
+- choose [one of the models with function calling feature](https://endpoints.ai.cloud.ovh.net/catalog) (e.g., [Qwen3-32B](https://endpoints.ai.cloud.ovh.net/models/qwen-3-32b), [Mistral-​Small-​3.2-​24B-​Instruct-​2506](https://endpoints.ai.cloud.ovh.net/models/mistral-small-3-2-24b-instruct-2506)) for best performance ;
+- choose any other model forcing structured output (`/set so` option).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ OVHCloud provides compatible LLM endpoints for using shai with tools. Start by c
 
 - [Qwen3-32B](https://endpoints.ai.cloud.ovh.net/models/qwen-3-32b)
 - [Mistral-​Small-​3.2-​24B-​Instruct-​2506](https://endpoints.ai.cloud.ovh.net/models/mistral-small-3-2-24b-instruct-2506)
-- [Llama-​3.1-​8B-​Instruct](https://endpoints.ai.cloud.ovh.net/models/llama-3-1-8b-instruct)
+- [Mistral-​Nemo-​Instruct-​2407](https://endpoints.ai.cloud.ovh.net/models/mistral-nemo-instruct-2407)
 - [Mistral-​7B-​Instruct-​v0.3](https://endpoints.ai.cloud.ovh.net/models/mistral-7b-instruct-v0-3)
 - [Meta-​Llama-​3_3-​70B-​Instruct](https://endpoints.ai.cloud.ovh.net/models/llama-3-3-70b-instruct)
+- [Llama-​3.1-​8B-​Instruct](https://endpoints.ai.cloud.ovh.net/models/llama-3-1-8b-instruct)
 - [DeepSeek-​R1-​Distill-​Llama-​70B](https://endpoints.ai.cloud.ovh.net/models/deepseek-r1-distill-llama-70b)


### PR DESCRIPTION
Adding the comprehensive list of OVHCloud-provided models compatible with shai. The latter seem to require models with "function calling" feature from [the catalog](https://endpoints.ai.cloud.ovh.net/catalog). Thus, this description clarifies how to access them and which ones are available to use.