### PR TITLE
feat: add token usage display

### DIFF
--- a/shai-cli/src/tui/command.rs
+++ b/shai-cli/src/tui/command.rs
@@ -9,6 +9,7 @@ impl App<'_> {
             (("/exit","exit from the tui"), vec![]),
             (("/auth","select a provider"), vec![]),
             (("/tc","set the tool call method: [fc | fc2 | so]"), vec!["method"]),
+            (("/tokens","display token usage (input/output)"), vec![]),
         ])
         .into_iter()
         .map(|((cmd,desc),args)|((cmd.to_string(),desc.to_string()),args.into_iter().map(|s|s.to_string()).collect()))
@@ -54,6 +55,15 @@ impl App<'_> {
                         _ => {}
                     }
                 }
+            }
+            "/tokens" => {
+                let msg = format!(
+                    "Token Usage - Input: {}, Output: {}, Total: {}",
+                    self.total_input_tokens,
+                    self.total_output_tokens,
+                    self.total_input_tokens + self.total_output_tokens
+                );
+                self.input.alert_msg(&msg, Duration::from_secs(5));
             }
             _ => {
                 self.input.alert_msg("command unknown", Duration::from_secs(1));

--- a/shai-cli/src/tui/helper.rs
+++ b/shai-cli/src/tui/helper.rs
@@ -14,14 +14,15 @@ impl HelpArea {
             "",
             "  Available Commands:",
             "  /exit                exit from the tui",
-            "  /tc <method>         set tool call method: [auto | fc | fc2 | so]"
+            "  /tc <method>         set tool call method: [auto | fc | fc2 | so]",
+            "  /tokens              display token usage"
         ].join("\n").to_string()
     }
 }
 
 impl HelpArea {
     pub fn height(&self) -> u16 {
-        7 // content (3 general help lines + 1 blank + 1 header + 2 command lines)
+        8 // content (3 general help lines + 1 blank + 1 header + 3 command lines)
     }
 
     pub fn draw(&self, f: &mut Frame, area: Rect) {

--- a/shai-core/src/agent/brain.rs
+++ b/shai-core/src/agent/brain.rs
@@ -27,28 +27,48 @@ pub enum ThinkerFlowControl {
 #[derive(Debug, Clone)]
 pub struct ThinkerDecision {
     pub message: ChatMessage,
-    pub flow:    ThinkerFlowControl
+    pub flow:    ThinkerFlowControl,
+    pub token_usage: Option<(u32, u32)>, // (input_tokens, output_tokens)
 }
 
 impl ThinkerDecision {
     pub fn new(message: ChatMessage) -> Self {
         ThinkerDecision{
             message,
-            flow: ThinkerFlowControl::AgentPause
+            flow: ThinkerFlowControl::AgentPause,
+            token_usage: None,
         }
     }
 
     pub fn agent_continue(message: ChatMessage) -> Self {
         ThinkerDecision{
             message,
-            flow: ThinkerFlowControl::AgentContinue
+            flow: ThinkerFlowControl::AgentContinue,
+            token_usage: None,
         }
     }
 
     pub fn agent_pause(message: ChatMessage) -> Self {
         ThinkerDecision{
             message,
-            flow: ThinkerFlowControl::AgentPause
+            flow: ThinkerFlowControl::AgentPause,
+            token_usage: None,
+        }
+    }
+
+    pub fn agent_continue_with_tokens(message: ChatMessage, input_tokens: u32, output_tokens: u32) -> Self {
+        ThinkerDecision{
+            message,
+            flow: ThinkerFlowControl::AgentContinue,
+            token_usage: Some((input_tokens, output_tokens)),
+        }
+    }
+
+    pub fn agent_pause_with_tokens(message: ChatMessage, input_tokens: u32, output_tokens: u32) -> Self {
+        ThinkerDecision{
+            message,
+            flow: ThinkerFlowControl::AgentPause,
+            token_usage: Some((input_tokens, output_tokens)),
         }
     }
 

--- a/shai-core/src/agent/events.rs
+++ b/shai-core/src/agent/events.rs
@@ -96,6 +96,11 @@ pub enum AgentEvent {
     Error { error: String },
     /// Agent execution completed
     Completed { success: bool, message: String },
+    /// Token usage information from LLM response
+    TokenUsage {
+        input_tokens: u32,
+        output_tokens: u32
+    },
 }
 
 /// Types of user input that an agent can request
@@ -261,6 +266,12 @@ impl std::fmt::Debug for AgentEvent {
                 f.debug_struct("Completed")
                     .field("success", success)
                     .field("message", message)
+                    .finish()
+            }
+            AgentEvent::TokenUsage { input_tokens, output_tokens } => {
+                f.debug_struct("TokenUsage")
+                    .field("input_tokens", input_tokens)
+                    .field("output_tokens", output_tokens)
                     .finish()
             }
         }

--- a/shai-core/src/agent/output/log.rs
+++ b/shai-core/src/agent/output/log.rs
@@ -53,6 +53,9 @@ impl FileEventLogger {
             AgentEvent::Completed { success, message } => {
                 format!("Completed: success={} - {}", success, message)
             }
+            AgentEvent::TokenUsage { input_tokens, output_tokens } => {
+                format!("Token Usage: input={} output={} total={}", input_tokens, output_tokens, input_tokens + output_tokens)
+            }
         };
 
         let log_line = format!("[{}] {}\n", timestamp.format("%Y-%m-%d %H:%M:%S%.3f"), event_str);

--- a/shai-core/src/agent/output/pretty.rs
+++ b/shai-core/src/agent/output/pretty.rs
@@ -110,6 +110,10 @@ impl PrettyFormatter {
                 
                 Some(completion_skin.term_text(&markdown).to_string())
             },
+            AgentEvent::TokenUsage { .. } => {
+                // Don't display token usage in the main output - it's handled by /tokens command
+                None
+            },
         }.map(|s| format!("\n{}", s))
     }
 

--- a/shai-core/src/runners/coder/coder.rs
+++ b/shai-core/src/runners/coder/coder.rs
@@ -77,15 +77,36 @@ impl Brain for CoderBrain {
                 context.method)
                 .await
                 .map_err(|e| AgentError::LlmError(e.to_string()))?;
-     
+
+        // Extract token usage information
+        let token_usage = if let Some(usage) = &brain_decision.usage {
+            let input = usage.prompt_tokens.unwrap_or(0);
+            let output = usage.completion_tokens.unwrap_or(0);
+            debug!(target: "brain::coder::tokens",
+                input_tokens = input,
+                output_tokens = output,
+                total_tokens = usage.total_tokens,
+                "Token usage for LLM call"
+            );
+            Some((input, output))
+        } else {
+            None
+        };
+
         // stop here if there's no other tool calls
         let message = brain_decision.choices.into_iter().next().unwrap().message;
         if let ChatMessage::Assistant { reasoning_content, content, tool_calls, .. } = &message {
             if tool_calls.as_ref().map_or(true, |calls| calls.is_empty()) {
-                return Ok(ThinkerDecision::agent_pause(message));
+                return Ok(match token_usage {
+                    Some((input_tokens, output_tokens)) => ThinkerDecision::agent_pause_with_tokens(message, input_tokens, output_tokens),
+                    None => ThinkerDecision::agent_pause(message),
+                });
             }
-        } 
-        Ok(ThinkerDecision::agent_continue(message))
+        }
+        Ok(match token_usage {
+            Some((input_tokens, output_tokens)) => ThinkerDecision::agent_continue_with_tokens(message, input_tokens, output_tokens),
+            None => ThinkerDecision::agent_continue(message),
+        })
     }
 }
 

--- a/shai-llm/src/providers/openai_compatible.rs
+++ b/shai-llm/src/providers/openai_compatible.rs
@@ -7,8 +7,10 @@ use openai_dive::v1::{
     resources::{
         chat::{ChatCompletionParameters, ChatCompletionResponse, ChatCompletionChunkResponse},
         model::ListModelResponse,
+        shared::Usage,
     },
 };
+use serde_json::Value;
 
 pub struct OpenAICompatibleProvider {
     client: Client,
@@ -42,8 +44,9 @@ impl LlmProvider for OpenAICompatibleProvider {
     }
 
     async fn chat(&self, request: ChatCompletionParameters) -> Result<ChatCompletionResponse, LlmError> {
-        let response = self.client.chat().create(request).await
+        let mut response = self.client.chat().create(request).await
             .map_err(|e| Box::new(e) as LlmError)?;
+
         Ok(response)
     }
 

--- a/shai-llm/src/providers/ovhcloud.rs
+++ b/shai-llm/src/providers/ovhcloud.rs
@@ -7,9 +7,11 @@ use openai_dive::v1::{
     resources::{
         chat::{ChatCompletionParameters, ChatCompletionResponse, ChatCompletionChunkResponse},
         model::ListModelResponse,
+        shared::Usage,
     },
     error::APIError
 };
+use serde_json::Value;
 
 const OVH_API_BASE: &str = "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1";
 
@@ -34,13 +36,13 @@ impl OvhCloudProvider {
         })
     }
 
-    fn sanitize_request(&self, mut request: ChatCompletionParameters) -> ChatCompletionParameters {        
+    fn sanitize_request(&self, mut request: ChatCompletionParameters) -> ChatCompletionParameters {
         // OVH uses max_tokens instead of max_completion_tokens
         if request.max_completion_tokens.is_some() {
             request.max_tokens = request.max_completion_tokens;
             request.max_completion_tokens = None;
         }
-        
+
         request
     }
 }
@@ -65,8 +67,9 @@ impl LlmProvider for OvhCloudProvider {
 
     async fn chat(&self, request: ChatCompletionParameters) -> Result<ChatCompletionResponse, LlmError> {
         let sanitized_request = self.sanitize_request(request);
-        let response = self.client.chat().create(sanitized_request).await
+        let mut response = self.client.chat().create(sanitized_request).await
             .map_err(|e| Box::new(e) as LlmError)?;
+
         Ok(response)
     }
 


### PR DESCRIPTION
Add token tracking for the `openai_compatible` and `ovhcloud` backends when the information is available, and display it via the `/tokens` endpoint. For integration into a token compressor.