### PR TITLE
c_char is unsigned on arm

### DIFF
--- a/shai-cli/src/shell/pty.rs
+++ b/shai-cli/src/shell/pty.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::thread;
 use std::io::{self, Read, Write};
 use std::sync::atomic::{AtomicI32, Ordering};
+use libc::c_char;
 use tempfile::NamedTempFile;
 
 use crate::fc::server::ShaiSessionServer;
@@ -96,7 +97,7 @@ impl ShaiPtyManager {
 
         let slave_fd = unsafe { 
             libc::open(
-                slave_name.as_ptr() as *const i8, 
+                slave_name.as_ptr() as *const c_char, 
                 libc::O_RDWR | libc::O_NOCTTY
             ) 
         };


### PR DESCRIPTION
fix #23 

I failed to build a static binary on arm for some reason but this fix lets user compile it properly in arm based environment.