### PR TITLE
feat(tui): add light theme support with auto-detection

### DIFF
--- a/shai-cli/src/tui/command.rs
+++ b/shai-cli/src/tui/command.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, io, time::Duration};
 use shai_llm::ToolCallMethod;
 
 use crate::tui::App;
+use super::theme::Theme;
 
 impl App<'_> {
     pub(crate) fn list_command() -> HashMap<(String, String),Vec<String>> {
@@ -10,6 +11,7 @@ impl App<'_> {
             (("/auth","select a provider"), vec![]),
             (("/tc","set the tool call method: [fc | fc2 | so]"), vec!["method"]),
             (("/tokens","display token usage (input/output)"), vec![]),
+            (("/theme","set theme: [dark | light | toggle]"), vec!["mode"]),
         ])
         .into_iter()
         .map(|((cmd,desc),args)|((cmd.to_string(),desc.to_string()),args.into_iter().map(|s|s.to_string()).collect()))
@@ -64,6 +66,35 @@ impl App<'_> {
                     self.total_input_tokens + self.total_output_tokens
                 );
                 self.input.alert_msg(&msg, Duration::from_secs(5));
+            }
+            "/theme" => {
+                match args.into_iter().next() {
+                    Some("dark") => {
+                        self.theme = Theme::Dark;
+                        let new_palette = self.theme.palette();
+                        self.input.set_palette(new_palette);
+                        self.input.alert_msg("Theme set to dark", Duration::from_secs(2));
+                    }
+                    Some("light") => {
+                        self.theme = Theme::Light;
+                        let new_palette = self.theme.palette();
+                        self.input.set_palette(new_palette);
+                        self.input.alert_msg("Theme set to light", Duration::from_secs(2));
+                    }
+                    Some("toggle") => {
+                        self.theme.toggle();
+                        let new_palette = self.theme.palette();
+                        self.input.set_palette(new_palette);
+                        let theme_name = match self.theme {
+                            Theme::Dark => "dark",
+                            Theme::Light => "light",
+                        };
+                        self.input.alert_msg(&format!("Theme toggled to {}", theme_name), Duration::from_secs(2));
+                    }
+                    _ => {
+                        self.input.alert_msg("Usage: /theme [dark|light|toggle]", Duration::from_secs(3));
+                    }
+                }
             }
             _ => {
                 self.input.alert_msg("command unknown", Duration::from_secs(1));

--- a/shai-cli/src/tui/perm_alt_screen.rs
+++ b/shai-cli/src/tui/perm_alt_screen.rs
@@ -17,18 +17,21 @@ use ratatui::{
 use shai_core::agent::events::PermissionRequest;
 
 use super::perm::{PermissionWidget, PermissionModalAction};
+use super::theme::ThemePalette;
 
 pub struct AlternateScreenPermissionModal<'a> {
     widget: PermissionWidget<'a>,
 }
 
 impl AlternateScreenPermissionModal<'_> {
-    pub fn new(widget: &PermissionWidget) -> io::Result<Self> {
+    pub fn new(widget: &PermissionWidget, palette: ThemePalette) -> io::Result<Self> {
         Ok(Self {
             widget: PermissionWidget::new(
                 widget.request_id.clone(),
                 widget.request.clone(),
-                widget.remaining_perms)
+                widget.remaining_perms,
+                palette
+            )
         })
     }
     

--- a/shai-cli/src/tui/theme.rs
+++ b/shai-cli/src/tui/theme.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use ratatui::style::Color;
 
 pub fn shai_logo() -> String {
     format!(r#"
@@ -16,6 +17,77 @@ pub static SHAI_YELLOW: (u8, u8, u8) = (249,188,81);
 pub static SHAI_GREEN: (u8, u8, u8)  = (18,200,124);
 pub static SHAI_BLUE: (u8,u8,u8) = (148,220,239);
 pub static SHAI_WHITE: (u8,u8,u8) = (200,200,200);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Theme {
+    Dark,
+    Light,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ThemePalette {
+    pub input_text: Color,
+    pub placeholder: Color,
+    pub border: Color,
+    pub status: Color,
+    pub method_label: Color,
+    pub suggestion_normal: Color,
+    pub suggestion_selected_fg: Color,
+    pub suggestion_selected_bg: Color,
+    pub cursor_fg: Color,
+    pub cursor_bg: Color,
+}
+
+impl Theme {
+    /// Read theme from SHAI_TUI_THEME environment variable
+    /// Defaults to Dark if not set or invalid
+    pub fn from_env() -> Self {
+        std::env::var("SHAI_TUI_THEME")
+            .ok()
+            .and_then(|s| match s.to_lowercase().as_str() {
+                "light" => Some(Theme::Light),
+                "dark" => Some(Theme::Dark),
+                _ => None,
+            })
+            .unwrap_or(Theme::Dark)
+    }
+
+    pub fn toggle(&mut self) {
+        *self = match self {
+            Theme::Dark => Theme::Light,
+            Theme::Light => Theme::Dark,
+        };
+    }
+
+    pub fn palette(&self) -> ThemePalette {
+        match self {
+            Theme::Dark => ThemePalette {
+                input_text: Color::White,
+                placeholder: Color::DarkGray,
+                border: Color::DarkGray,
+                status: Color::Yellow,
+                method_label: Color::DarkGray,
+                suggestion_normal: Color::White,
+                suggestion_selected_fg: Color::Yellow,
+                suggestion_selected_bg: Color::DarkGray,
+                cursor_fg: Color::White,
+                cursor_bg: Color::White,
+            },
+            Theme::Light => ThemePalette {
+                input_text: Color::Black,
+                placeholder: Color::Rgb(120, 120, 120),  // Medium gray
+                border: Color::Rgb(100, 100, 100),       // Darker gray for visibility
+                status: Color::Rgb(200, 100, 0),         // Orange (readable on white)
+                method_label: Color::Rgb(100, 100, 100), // Same as border
+                suggestion_normal: Color::Black,
+                suggestion_selected_fg: Color::Black,
+                suggestion_selected_bg: Color::Rgb(255, 220, 100), // Light yellow highlight
+                cursor_fg: Color::Black,
+                cursor_bg: Color::Black,
+            },
+        }
+    }
+}
 
 fn rgb_to_256_color(r: u8, g: u8, b: u8) -> u8 {
     let r_index = (r as f32 / 255.0 * 5.0).round() as u8;


### PR DESCRIPTION
Fixes #63

Changes

- Support `SHAI_TUI_THEME` environment variable (dark/light) for auto-detection on startup
- Added `/theme` command with `dark`, `light`, and `toggle` options

How to Use

**Set theme via environment variable:**
```bash
SHAI_TUI_THEME=light shai
```

or use commands at runtime 

```bash
/theme light (or dark)
```


Screenshots:

light theme 
<img width="1482" height="770" alt="image" src="https://github.com/user-attachments/assets/46f91578-9cd2-4043-b323-a15e1dfa7053" />

dark theme
<img width="1127" height="495" alt="image" src="https://github.com/user-attachments/assets/bd7fa40d-e02f-476d-b103-8f9ab748bb72" />


Signed-off-by: Ayan ayansheikh52@gmail.com