### PR TITLE
easier agent configuration

### DIFF
--- a/.ovh.config
+++ b/.ovh.config
@@ -1,14 +1,6 @@
 {
   "name": "ovh",
   "description": "OVH agent with OVH MCP server for cloud management and API calls",
-  "llm_provider": {
-    "provider": "ovhcloud",
-    "env_vars": {
-      "OVH_BASE_URL": "https://gpt-oss-120b.endpoints.kepler.ai.cloud.ovh.net/api/openai_compat/v1"
-    },
-    "model": "gpt-oss-120b",
-    "tool_method": "FunctionCall"
-  },
   "tools": {
     "builtin": ["*"],
     "mcp": {
@@ -17,7 +9,10 @@
           "type": "http",
           "url": "https://mcp.eu.ovhcloud.com/mcp"
         },
-        "enabled_tools": ["*"]
+        "enabled_tools": ["*"],
+        "excluded_tools": [
+          "get-cloud-project-flavor-list"
+        ]
       }
     }
   },

--- a/README.md
+++ b/README.md
@@ -137,16 +137,17 @@ Instead of a single global configuration, you can create custom agent in a separ
 
 [`.ovh.config`](./.ovh.config) contains an example of a custom configuration with an remote MCP server configured.
 
-Place this file in `~/.config/shai/agents/example.config`, you can then list the agents available with:
+Place this file in `~/.config/shai/agents/ovh.config`, you can then list the agents available with:
 
 ```bash
+curl https://raw.githubusercontent.com/ovh/shai/refs/heads/main/.ovh.config -o ˜/.config/shai/agents/ovh.config
 shai agent list
 ```
 
 You can run shai with this specific agent with the `agent` subcommand:
 
 ```bash
-shai agent example
+shai agent ovh
 ```
 
 ### OVHCloud Endpoints

--- a/shai-core/examples/oauth_test.rs
+++ b/shai-core/examples/oauth_test.rs
@@ -3,12 +3,22 @@ use shai_core::tools::mcp::mcp_oauth::signin_oauth;
 #[tokio::main]
 async fn main() {
     println!("🚀 Starting OAuth flow test...");
-    
+
     match signin_oauth("https://mcp.eu.ovhcloud.com/").await {
-        Ok(access_token) => {
+        Ok(token) => {
             println!("✅ OAuth flow completed successfully!");
-            println!("🎫 Access Token: {}", access_token);
-            println!("🔑 Token length: {} characters", access_token.len());
+            println!("🎫 Access Token: {}", token.access_token);
+            println!("🔑 Token length: {} characters", token.access_token.len());
+            if let Some(expires_at) = token.expires_at {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs() as i64;
+                let seconds_until_expiry = expires_at - now;
+                println!("⏰ Token expires in {} seconds", seconds_until_expiry);
+            } else {
+                println!("⏰ Token has no expiration");
+            }
         }
         Err(e) => {
             println!("❌ OAuth flow failed: {}", e);

--- a/shai-core/src/config/config.rs
+++ b/shai-core/src/config/config.rs
@@ -199,8 +199,8 @@ impl ShaiConfig {
             .map(|(name, config)| {
                 let description = match config {
                     McpConfig::Stdio { command, .. } => format!("stdio: {}", command),
-                    McpConfig::Http { url, bearer_token } => {
-                        if bearer_token.is_some() {
+                    McpConfig::Http { url, auth } => {
+                        if auth.is_some() {
                             format!("http: {} (authenticated)", url)
                         } else {
                             format!("http: {}", url)

--- a/shai-core/src/tools/mcp/mcp_config.rs
+++ b/shai-core/src/tools/mcp/mcp_config.rs
@@ -4,14 +4,43 @@ use serde::{Serialize, Deserialize};
 use super::{StdioClient, HttpClient, SseClient};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthToken {
+    pub access_token: String,
+    /// Unix timestamp (seconds since epoch) when the token expires
+    pub expires_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum McpConfig {
     #[serde(rename = "stdio")]
     Stdio { command: String, args: Vec<String> },
     #[serde(rename = "http")]
-    Http { url: String, bearer_token: Option<String> },
+    Http {
+        url: String,
+        #[serde(flatten)]
+        auth: Option<OAuthToken>
+    },
     #[serde(rename = "sse")]
     Sse { url: String },
+}
+
+impl OAuthToken {
+    /// Check if the token is expired or will expire within the next 60 seconds
+    pub fn is_expired(&self) -> bool {
+        if let Some(expires_at) = self.expires_at {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64;
+
+            // Consider expired if it expires within the next 60 seconds (safety margin)
+            expires_at <= now + 60
+        } else {
+            // If no expiration time, assume it's still valid
+            false
+        }
+    }
 }
 
 /// Factory function to create an MCP client from configuration
@@ -20,7 +49,8 @@ pub fn create_mcp_client(config: McpConfig) -> Box<dyn McpClient> {
         McpConfig::Stdio { command, args } => {
             Box::new(StdioClient::new(command, args))
         }
-        McpConfig::Http { url, bearer_token } => {
+        McpConfig::Http { url, auth } => {
+            let bearer_token = auth.map(|t| t.access_token);
             Box::new(HttpClient::new_with_auth(url, bearer_token))
         }
         McpConfig::Sse { url } => {

--- a/shai-core/src/tools/mcp/mod.rs
+++ b/shai-core/src/tools/mcp/mod.rs
@@ -9,7 +9,7 @@ pub mod mcp_oauth;
 mod tests;
 
 pub use mcp::{McpClient, McpToolDescription, get_mcp_tools};
-pub use mcp_config::{McpConfig, create_mcp_client};
+pub use mcp_config::{McpConfig, OAuthToken, create_mcp_client};
 pub use mcp_stdio::StdioClient;
 pub use mcp_http::HttpClient;
 pub use mcp_sse::SseClient;

--- a/shai-core/src/tools/mcp/tests.rs
+++ b/shai-core/src/tools/mcp/tests.rs
@@ -148,7 +148,7 @@ mod tests {
         // Test HTTP config
         let http_config = McpConfig::Http {
             url: "http://localhost:8080".to_string(),
-            bearer_token: None
+            auth: None
         };
         let _http_client = create_mcp_client(http_config);
         println!("✅ Successfully created HttpClient via factory");


### PR DESCRIPTION
- If the llm provider configuration is not set in the agent specific config, it uses the global one
- also if the mcp token is expired, it sets a new oauth flow