### PR TITLE
mcp required option

### DIFF
--- a/shai-core/src/config/agent.rs
+++ b/shai-core/src/config/agent.rs
@@ -21,6 +21,10 @@ pub struct McpToolConfig {
     pub enabled_tools: Vec<String>,
     #[serde(default)]
     pub excluded_tools: Vec<String>,
+    /// Whether this MCP server is required to start successfully (default: false)
+    /// If false, connection errors will be logged as warnings and agent will continue
+    #[serde(default)]
+    pub required: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
add a flag to specify wether an MCP is required or not, default to false. If required flag is set, shai won't start if mcp cannot be connected to.

fix issue #107