### PR TITLE
docs: fix typo in OVHCloud endpoints instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ shai agent ovh
 
 ### OVHCloud Endpoints
 
-OVHCloud provides compatible LLM endpoints for using shai with tools. Start by creating a [_Public Cloud_ project in your OVHCloud account](https://www.ovh.com/manager/#/public-cloud), then head to _AI Endpoints_ and retreive your API key. After setting it in shai, you can:
+OVHCloud provides compatible LLM endpoints for using shai with tools. Start by creating a [_Public Cloud_ project in your OVHCloud account](https://www.ovh.com/manager/#/public-cloud), then head to _AI Endpoints_ and retrieve your API key. After setting it in shai, you can:
 
 - choose [one of the models with function calling feature](https://endpoints.ai.cloud.ovh.net/catalog) (e.g., [gpt-oss-120b](https://endpoints.ai.cloud.ovh.net/models/gpt-oss-120b), [gpt-oss-20b](https://endpoints.ai.cloud.ovh.net/models/gpt-oss-20b), [Mistral-​Small-​3.2-​24B-​Instruct-​2506](https://endpoints.ai.cloud.ovh.net/models/mistral-small-3-2-24b-instruct-2506)) for best performance ;
 - choose any other model forcing structured output (`/set so` option).


### PR DESCRIPTION
## Summary
- Fix a small typo in the OVHCloud endpoints setup instructions (`retreive` -> `retrieve`).

## Testing
- Documentation-only change; no tests run.